### PR TITLE
Add @mutates decorator

### DIFF
--- a/flopsy/__init__.py
+++ b/flopsy/__init__.py
@@ -1,4 +1,4 @@
 from .action import Action
 from .store import Store
-from .reducer import reducer
+from .reducer import mutates, reducer
 from .saga import saga

--- a/flopsy/inspector/inspector.py
+++ b/flopsy/inspector/inspector.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import copy
+import sys
 from datetime import datetime
 from threading import Thread
 from imgui.integrations.glfw import GlfwRenderer

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # build with 'python ./setup.py install'
 from distutils.core import setup
 
-VERSION = "0.0.3"
+VERSION = "0.0.4"
 
 setup(
     name = 'flopsy',
@@ -13,7 +13,7 @@ setup(
     author = 'Bill Gribble',
     author_email = 'grib@billgribble.com',
     url = 'https://github.com/bgribble/flopsy',
-    download_url = 'https://github.com/bgribble/flopsy/archive/refs/tags/0.0.3.tar.gz',
+    download_url = f'https://github.com/bgribble/flopsy/archive/refs/tags/{VERSION}.tar.gz',
     keywords = ['state-management', 'redux', 'saga'],
     install_requires = [
         'pyopengl', 'glfw', 'imgui[glfw]',


### PR DESCRIPTION
I have started to build out the state management in MFP, and I'm finding areas where Flopsy's API could support it better.

This one is useful when you are retrofitting state management into a class that already has methods that change state variables directly. 

```
@mutates('state_1')
def update_some_stuff(self, *args)
    self.state_1 = newval
```

The decorator will stash the previous value of `state_1` before calling the mutator, then compare for equality after the call and update the store by dispatching `SET_STATE_1` if `state_1` has changed.  