### PR TITLE
Bug fixes; change imgui distribution; release 0.0.5

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -96,6 +96,7 @@ class UndoableState(Store):
         yield
 
 async def main():
+    Store.setup_asyncio()
     Store.show_inspector()
     await asyncio.sleep(0.5)
     store = UndoableState()

--- a/flopsy/__init__.py
+++ b/flopsy/__init__.py
@@ -2,3 +2,4 @@ from .action import Action
 from .store import Store
 from .reducer import mutates, reducer
 from .saga import saga
+from .inspector.inspector import Inspector

--- a/flopsy/action.py
+++ b/flopsy/action.py
@@ -8,5 +8,8 @@ class Action:
         self.type_name = type_name
         self.payload = payload
 
+    def __str__(self):
+        return f"<Action {self.type_name} {self.payload}>"
+
     def dispatch(self):
         return self.target.dispatch(self)

--- a/flopsy/inspector/inspector.py
+++ b/flopsy/inspector/inspector.py
@@ -1,23 +1,43 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
+"""
+inspector.py -- state timeline and visualizer
+
+Copyright (c) 2022-2024 Bill Gribble <grib@billgribble.com>
+"""
 import asyncio
+import ctypes
 import json
 import copy
-import sys
+import OpenGL.GL as gl
+from sdl2 import *  # noqa
 from datetime import datetime
 from threading import Thread
-from imgui.integrations.glfw import GlfwRenderer
-import OpenGL.GL as gl
-import glfw
-import imgui
+from imgui_bundle import imgui
 from flopsy.action import Action
 from flopsy.store import Store
+from imgui_bundle.python_backends.sdl_backend import SDL2Renderer
 
 
 class Inspector(Thread):
-    def __init__(self, *, event_loop=None, width=800, height=600):
+    """
+    imgui display for viewing and interacting with state.
+
+    Modeled after the Redux devtools for Chrome.
+
+    Can run its own main loop (using GLFW) in a thread:
+    Inspector().start()
+
+    Or you can integrate it into an existing imgui app
+    by creating an Inspector and calling render()
+    """
+    def __init__(
+        self, *,
+        title="Flopsy inspector",
+        event_loop=None,
+        width=800, height=600
+    ):
         super().__init__()
-        self.window_name = "Flopsy inspector"
+        self.window_name = title
         self.window_width = width
         self.window_height = height
 
@@ -29,12 +49,17 @@ class Inspector(Thread):
         self.timeline = []
 
         self.event_loop = event_loop or asyncio.get_event_loop()
+        self.window = None
+        self.needs_focus = False
 
         self.initial_store = Store.store()
         self.initial_store_ts = datetime.now()
         self.current_store = copy.copy(self.initial_store)
 
         self.store_listen()
+
+    def focus(self):
+        self.needs_focus = True
 
     async def update_timeline(self, store, action, state_diff):
         if action not in [t[1] for t in self.timeline]:
@@ -93,85 +118,64 @@ class Inspector(Thread):
                 new_value = values[1] if incr > 0 else values[0]
                 store_item_content[state_key] = new_value
 
-    def create_glfw_window(self):
-        if not glfw.init():
-            print("Could not initialize OpenGL context")
-            return None
-
-        # OS X supports only forward-compatible core profiles from 3.2
-        glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
-        glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
-        glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
-
-        glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, gl.GL_TRUE)
-
-        # Create a windowed mode window and its OpenGL context
-        window = glfw.create_window(
-            int(self.window_width),
-            int(self.window_height),
-            self.window_name,
-            None,
-            None
-        )
-        glfw.make_context_current(window)
-
-        if not window:
-            glfw.terminate()
-            print("Could not initialize Window")
-            return None
-
-        return window
-
-    def imgui_paint(self):
+    def render(self):
+        """
+        render()
+        """
         keep_going = True
 
-        ########################################
-        # global menu bar
-        if imgui.begin_main_menu_bar():
-            if imgui.begin_menu("File"):
+        # one window that fills the workspace
+        imgui.set_next_window_size([self.window_width, self.window_height])
+        imgui.get_style().window_rounding = 0
+        imgui.style_colors_light()
 
-                clicked, enabled = imgui.menu_item("Clear timeline")
+        if self.window:
+            imgui.set_next_window_pos([0, 0])
+            flags = (
+                imgui.WindowFlags_.no_move
+                | imgui.WindowFlags_.always_auto_resize
+                | imgui.WindowFlags_.menu_bar
+            )
+        else:
+            flags = imgui.WindowFlags_.menu_bar
+
+        imgui.begin(
+            "Flopsy Inspector",
+            flags=flags,
+        )
+        if self.needs_focus:
+            imgui.set_window_focus()
+            imgui.set_window_collapsed(False)
+            self.needs_focus = False
+
+        ########################################
+        # menu bar
+        if imgui.begin_menu_bar():
+            if imgui.begin_menu("Inspector"):
+                clicked, _ = imgui.menu_item("Clear timeline", "", False)
                 if clicked:
                     self.timeline = []
                     self.current_store = Store.store()
                     self.timeline_item_selected = None
 
-                clicked, enabled = imgui.menu_item("Follow timeline")
+                clicked, _ = imgui.menu_item("Follow timeline", "", False)
                 if clicked:
                     self.current_store = Store.store()
                     self.timeline_item_selected = None
 
                 # Quit
-                clicked, rest = imgui.menu_item("Quit", "Ctrl+Q")
+                clicked, _ = imgui.menu_item("Close", "Ctrl+w", False)
                 if clicked:
                     keep_going = False
                     self.store_unlisten()
                 imgui.end_menu()
-
-            imgui.end_main_menu_bar()
-
-        # one window that fills the workspace
-        imgui.set_next_window_size(self.window_width, self.window_height-21)
-        imgui.set_next_window_position(0, 21)
-        imgui.get_style().window_rounding = 0
-        imgui.style_colors_light()
-
-        imgui.begin(
-            "Flopsy Inspector",
-            closable=False,
-            flags=imgui.WINDOW_NO_MOVE| imgui.WINDOW_ALWAYS_AUTO_RESIZE,
-        )
+            imgui.end_menu_bar()
 
         ########################################
         # timeline
         halfwidth = imgui.get_window_width() * 0.5
-        fullheight = imgui.get_window_height()
-        imgui.set_next_window_size(halfwidth, fullheight)
-        imgui.set_next_window_position(0, 21)
-        imgui.begin(
-            "Timeline",
-            closable=False,
-            flags=imgui.WINDOW_NO_COLLAPSE|imgui.WINDOW_NO_MOVE|imgui.WINDOW_NO_RESIZE,
+        imgui.begin_child(
+            "Timeline", [halfwidth, 0], True
         )
         items = [
             (
@@ -186,10 +190,10 @@ class Inspector(Thread):
 
         for counter, item in enumerate(items):
             i_label, i_target, i_payload, i_state_diff = item
-            flags = imgui.TREE_NODE_OPEN_ON_DOUBLE_CLICK
+            flags = imgui.TreeNodeFlags_.open_on_double_click
             if self.timeline_item_selected == counter:
-                flags |= imgui.TREE_NODE_SELECTED
-            opened = imgui.tree_node(f"{i_label}##{counter}", flags)
+                flags |= imgui.TreeNodeFlags_.selected
+            opened = imgui.tree_node_ex(f"{i_label}##{counter}", flags)
             if imgui.is_item_clicked():
                 self.update_timeline_selection(counter)
             if opened:
@@ -205,17 +209,13 @@ class Inspector(Thread):
 
                 imgui.tree_pop()
         imgui.end_child()
-
-        imgui.end()
+        imgui.end_child()
 
         ########################################
         # store
-        imgui.set_next_window_size(halfwidth, fullheight)
-        imgui.set_next_window_position(halfwidth, 21)
-        imgui.begin(
-            "Store",
-            closable=False,
-            flags=imgui.WINDOW_NO_COLLAPSE|imgui.WINDOW_NO_MOVE|imgui.WINDOW_NO_RESIZE,
+        imgui.same_line()
+        imgui.begin_child(
+            "Store", [halfwidth, 0], True
         )
 
         if self.timeline_item_selected is not None:
@@ -245,9 +245,11 @@ class Inspector(Thread):
                                 imgui.push_item_width(
                                     0.5 * imgui.get_window_width()
                                 )
-                                changed, self.store_item_selected_value = imgui.input_text(
-                                    "##store_edit_input",
-                                    self.store_item_selected_value
+                                _, self.store_item_selected_value = (
+                                    imgui.input_text(
+                                        "##store_edit_input",
+                                        self.store_item_selected_value
+                                    )
                                 )
                                 imgui.pop_item_width()
                                 imgui.same_line()
@@ -258,7 +260,7 @@ class Inspector(Thread):
                                     )
                                     self.store_item_selected = None
                             else:
-                                selected, _ = imgui.selectable(f"{store_value}")
+                                selected, _ = imgui.selectable(f"{store_value}", False)
                                 if selected:
                                     self.store_item_selected = item_id
                                     self.store_item_selected_value = str(store_value)
@@ -266,39 +268,115 @@ class Inspector(Thread):
                         imgui.tree_pop()
                 imgui.tree_pop()
         imgui.end_child()
-
+        imgui.end_child()
+        self.window_width, self.window_height = imgui.get_window_size()
         imgui.end()
 
-        imgui.end()
         return keep_going
+
+    #####################
+    # main loop routines -- needed if you aren't calling
+    # render() directly from a containing app
+
+    def create_sdl2_window(self, name, width, height):
+        if SDL_Init(SDL_INIT_EVERYTHING) < 0:
+            Store.log(
+                "[sdl2] Error: SDL could not initialize! SDL Error: "
+                + SDL_GetError().decode("utf-8")
+            )
+            return None, None
+
+        SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1)
+        SDL_GL_SetAttribute(SDL_GL_DEPTH_SIZE, 24)
+        SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 8)
+        SDL_GL_SetAttribute(SDL_GL_ACCELERATED_VISUAL, 1)
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLEBUFFERS, 1)
+        SDL_GL_SetAttribute(SDL_GL_MULTISAMPLESAMPLES, 8)
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG)
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4)
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 1)
+        SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE)
+
+        SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, b"1")
+        SDL_SetHint(SDL_HINT_VIDEO_HIGHDPI_DISABLED, b"1")
+        SDL_SetHint(SDL_HINT_VIDEODRIVER, b"wayland,x11")
+        SDL_SetHint(SDL_HINT_VIDEO_X11_FORCE_EGL, b"1")
+        SDL_SetHint(SDL_HINT_APP_NAME, name.encode('utf-8'))
+
+        window = SDL_CreateWindow(
+            name.encode("utf-8"),
+            SDL_WINDOWPOS_CENTERED,
+            SDL_WINDOWPOS_CENTERED,
+            width,
+            height,
+            SDL_WINDOW_OPENGL | SDL_WINDOW_RESIZABLE,
+        )
+
+        if window is None:
+            Store.log(
+                "[sdl2] Error: Window could not be created! SDL Error: "
+                + SDL_GetError().decode("utf-8")
+            )
+            return None, None
+
+        gl_context = SDL_GL_CreateContext(window)
+        if gl_context is None:
+            Store.log(
+                "[sdl2] Error: Cannot create OpenGL Context! SDL Error: "
+                + SDL_GetError().decode("utf-8")
+            )
+            return None, None
+
+        SDL_GL_MakeCurrent(window, gl_context)
+        if SDL_GL_SetSwapInterval(1) < 0:
+            Store.log(
+                "[sdl2] Error: Unable to set VSync! SDL Error: " + SDL_GetError().decode("utf-8")
+            )
+            return None, None
+        return window, gl_context
 
     def run(self):
         # set up the window and renderer context
-        imgui.create_context()
-        window = self.create_glfw_window()
-        impl = GlfwRenderer(window)
+        ctx = imgui.create_context()
+        imgui.set_current_context(ctx)
+        window, gl_context = self.create_sdl2_window(self.window_name, self.window_width, self.window_height)
+        self.window = window
+        impl = SDL2Renderer(window)
 
         keep_going = True
 
-        while keep_going and not glfw.window_should_close(window):
+        event = SDL_Event()
+        width = ctypes.c_int()
+        height = ctypes.c_int()
+
+        while keep_going:
             # top of loop stuff
-            glfw.poll_events()
+            while SDL_PollEvent(ctypes.byref(event)) != 0:
+                SDL_GetWindowSize(self.window, width, height)
+                w_width = int(width.value)
+                w_height = int(height.value)
+                if w_width != self.window_width or w_height != self.window_height:
+                    self.window_width = w_width
+                    self.window_height = w_height
+
+                if event.type == SDL_QUIT:
+                    keep_going = False
+                impl.process_event(event)
+
             impl.process_inputs()
             imgui.new_frame()
 
-            width, height = glfw.get_window_size(window)
-            self.window_width = width
-            self.window_height = height
-
             # hard work
-            keep_going = self.imgui_paint()
+            keep_going = self.render()
 
             # bottom of loop stuff
             gl.glClearColor(1.0, 1.0, 1.0, 1)
             gl.glClear(gl.GL_COLOR_BUFFER_BIT)
             imgui.render()
             impl.render(imgui.get_draw_data())
-            glfw.swap_buffers(window)
+            SDL_GL_SwapWindow(window)
 
         impl.shutdown()
-        glfw.terminate()
+        SDL_GL_DeleteContext(gl_context)
+        SDL_DestroyWindow(self.window)
+        SDL_Quit()

--- a/flopsy/inspector/inspector.py
+++ b/flopsy/inspector/inspector.py
@@ -140,7 +140,7 @@ class Inspector(Thread):
             flags = imgui.WindowFlags_.menu_bar
 
         imgui.begin(
-            "Flopsy Inspector",
+            self.window_name,
             flags=flags,
         )
         if self.needs_focus:

--- a/flopsy/reducer.py
+++ b/flopsy/reducer.py
@@ -92,8 +92,7 @@ class reducer:
         pass
 
     if the reducer has args, they are interpreted as the
-    state elements to run this reducer for. If there are
-    no args it will get run for any state change.
+    state elements that this reducer affects.
     """
     def __init__(self, *args):
         self.owning_class = None

--- a/flopsy/reducer.py
+++ b/flopsy/reducer.py
@@ -126,6 +126,12 @@ class reducer:
         setattr(owner, self.method_name, self.func)
         setattr(owner, self.action_name, self.action_name)
 
+        # ... but sometimes it's not exactly the right time 
+        if '_next_reducer_id' not in self.owning_class.__dict__:
+            self.owning_class._next_reducer_id = 1
+        if '_store_reducers' not in self.owning_class.__dict__:
+            self.owning_class._store_reducers = {}
+
         handlers = owner._store_reducers.setdefault(self.action_name, [])
 
         if self.states is None:

--- a/flopsy/saga.py
+++ b/flopsy/saga.py
@@ -1,3 +1,5 @@
+import logging
+logger = logging.getLogger(__name__)
 
 class saga:
     """
@@ -6,17 +8,17 @@ class saga:
     method is reassigned to a new name with a preceding _
 
     @saga
-    def my_saga(self, action, state_diff):
+    async def my_saga(self, action, state_diff):
         # this is a saga that runs after all dispatchers
         # for "action". It should be an async generator --
         # that is, an async function that uses yield to
         # return a sequence of values.
         pass
 
-    if the reducer has args, they are interpreted as the
-    state elements. The saga will only be run after an action
-    that affects the named state items. If there are
-    no args it will get run after any action.
+    if the decorator has args, they are interpreted as the state
+    elements that are connected to the saga. The saga will only
+    be run after an action that affects the named state items. If
+    there are no args it will get run after any action.
     """
     def __init__(self, *args):
         self.owning_class = None
@@ -44,11 +46,21 @@ class saga:
         self.method_name = '_' + self.action_name
 
     # __set_name__ gets called because @saga is a "descriptor",
-    # at the right time in the init process
+    # at the right time in the init process.
     def __set_name__(self, owner, name):
+        from .store import Store
+
         self.owning_class = owner
         setattr(owner, self.method_name, self.func)
         setattr(owner, self.action_name, self.action_name)
+
+        # __set_name__ is called before the parent
+        # __init_subclass__ so these class attributes might not
+        # be defined yet
+        if '_next_saga_id' not in self.owning_class.__dict__:
+            self.owning_class._next_saga_id = 1
+        if '_store_sagas' not in self.owning_class.__dict__:
+            self.owning_class._store_sagas = []
 
         saga_id = self.owning_class._next_saga_id
         self.owning_class._next_saga_id += 1

--- a/flopsy/saga.py
+++ b/flopsy/saga.py
@@ -1,5 +1,3 @@
-import logging
-logger = logging.getLogger(__name__)
 
 class saga:
     """
@@ -20,12 +18,13 @@ class saga:
     be run after an action that affects the named state items. If
     there are no args it will get run after any action.
     """
-    def __init__(self, *args):
+    def __init__(self, *args, **kwargs):
         self.owning_class = None
         self.func = None
         self.states = None
         self.action_name = None
         self.method_name = None
+        self.on_store_init = kwargs.get("on_init", False)
 
         # if no args to @reducer
         if len(args) == 1 and callable(args[0]):
@@ -64,5 +63,5 @@ class saga:
 
         saga_id = self.owning_class._next_saga_id
         self.owning_class._next_saga_id += 1
-        self.owning_class._store_sagas.append((saga_id, self, self.states))
+        self.owning_class._store_sagas.append((saga_id, self, self.states, self.on_store_init))
 

--- a/flopsy/store.py
+++ b/flopsy/store.py
@@ -219,7 +219,7 @@ class Store:
             launched = asyncio.create_task(task)
         else:
             launched = asyncio.run_coroutine_threadsafe(
-                task, Store._store_asyncio_loop
+                task, Store._store_asyncio_event_loop
             )
 
         # save the new task for later cleanup
@@ -299,7 +299,9 @@ class Store:
     @staticmethod
     def show_inspector(event_loop=None):
         from .inspector.inspector import Inspector
-        inspector = Inspector(event_loop=event_loop)
+        inspector = Inspector(
+            event_loop=event_loop,
+        )
         inspector.start()
         return inspector
 
@@ -312,7 +314,7 @@ class Store:
     @staticmethod
     def setup_asyncio():
         Store._store_asyncio_thread = threading.get_ident()
-        Store._store_asyncio_loop = asyncio.get_event_loop()
+        Store._store_asyncio_event_loop = asyncio.get_event_loop()
 
 
 class SyncedStore (Store):

--- a/flopsy/store.py
+++ b/flopsy/store.py
@@ -83,14 +83,17 @@ class Store:
             getter_statename = f"{attr.upper()}"
 
             # define the name as a symbol
-            setattr(cls, setter_action, setter_action)
-            setattr(cls, getter_statename, attr)
+            if not hasattr(cls, setter_action):
+                setattr(cls, setter_action, setter_action)
+
+            if not hasattr(cls, getter_statename):
+                setattr(cls, getter_statename, attr)
 
             # define the setter as a method
-            setattr(cls, setter_methodname, setter_dispatch)
+            if not hasattr(cls, setter_methodname):
+                setattr(cls, setter_methodname, setter_dispatch)
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
         id_attr = getattr(self, "store_id_attr", None)
         if id_attr is None:
             id_attr = "id"
@@ -132,6 +135,17 @@ class Store:
         Displayed in the inspector along with the ID, if implemented
         """
         return None
+
+    def store_setter(self, param_name):
+        """
+        Return a bound method that can be called to dispatch a setter
+
+        obj.store_setter(param)(new_value) is equivalent to
+        obj._SET_PARAM(new_value) but doesn't require caller to know
+        how setters are named
+        """
+        setter = getattr(self, f'_SET_{param_name.upper()}')
+        return setter
 
     async def dispatch(self, action, previous=None):
         """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # build with 'python ./setup.py install'
 from distutils.core import setup
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 setup(
     name = 'flopsy',
@@ -16,7 +16,7 @@ setup(
     download_url = f'https://github.com/bgribble/flopsy/archive/refs/tags/v{VERSION}.tar.gz',
     keywords = ['state-management', 'redux', 'saga'],
     install_requires = [
-        'pyopengl', 'glfw', 'imgui[glfw]',
+        'pyopengl', 'glfw', 'imgui_bundle',
     ],
     classifiers = [
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This release changes the Imgui bindings distribution that the Inspector uses from `pyimgui` to `imgui_bundle`. There are a few differences in the way Imgui datatypes are implemented. 

Also, in advance of the first release of the Imgui backend for [mfp](https://github/com/bgribble/mfp), a number of changes were made to allow the inspector to work in an existing Imgui app, and also to support new use cases and fix bugs that I found during the MFP work. 